### PR TITLE
Initialized supportedNetworksMapping in the constructor of the Helper contract and funded the TokenTransferor contract with LINK and CCIP-BnM tokens in the test_tranferTokensFromEoaToEoaPayFeesInLink test

### DIFF
--- a/script/Helper.sol
+++ b/script/Helper.sol
@@ -115,6 +115,18 @@ contract Helper {
     address constant ghoArbitrumSepolia = 0xb13Cfa6f8B2Eed2C37fB00fF0c1A59807C585810;
 
     constructor() {
+        supportedNetworksMapping["Ethereum Sepolia"] = SupportedNetworks.ETHEREUM_SEPOLIA;
+        supportedNetworksMapping["Avalanche Fuji"] = SupportedNetworks.AVALANCHE_FUJI;
+        supportedNetworksMapping["Arbitrum Sepolia"] = SupportedNetworks.ARBITRUM_SEPOLIA;
+        supportedNetworksMapping["Polygon Amoy"] = SupportedNetworks.POLYGON_AMOY;
+        supportedNetworksMapping["BNB Chain Testnet"] = SupportedNetworks.BNB_CHAIN_TESTNET;
+        supportedNetworksMapping["Optimism Sepolia"] = SupportedNetworks.OPTIMISM_SEPOLIA;
+        supportedNetworksMapping["Base Sepolia"] = SupportedNetworks.BASE_SEPOLIA;
+        supportedNetworksMapping["Wemix Testnet"] = SupportedNetworks.WEMIX_TESTNET;
+        supportedNetworksMapping["Kroma Sepolia"] = SupportedNetworks.KROMA_SEPOLIA;
+        supportedNetworksMapping["Gnosis Chiado"] = SupportedNetworks.GNOSIS_CHIADO;
+        supportedNetworksMapping["Celo Alfajores"] = SupportedNetworks.CELO_ALFAJORES;
+
         networks[SupportedNetworks.ETHEREUM_SEPOLIA] = "Ethereum Sepolia";
         networks[SupportedNetworks.AVALANCHE_FUJI] = "Avalanche Fuji";
         networks[SupportedNetworks.ARBITRUM_SEPOLIA] = "Arbitrum Sepolia";

--- a/src/TokenTransferor.sol
+++ b/src/TokenTransferor.sol
@@ -4,9 +4,12 @@ pragma solidity 0.8.19;
 import {IRouterClient} from "@chainlink/contracts-ccip/src/v0.8/ccip/interfaces/IRouterClient.sol";
 import {OwnerIsCreator} from "@chainlink/contracts-ccip/src/v0.8/shared/access/OwnerIsCreator.sol";
 import {Client} from "@chainlink/contracts-ccip/src/v0.8/ccip/libraries/Client.sol";
-import {IERC20} from "@chainlink/contracts-ccip/src/v0.8/vendor/openzeppelin-solidity/v4.8.3/contracts/token/ERC20/IERC20.sol";
-import {SafeERC20} from "@chainlink/contracts-ccip/src/v0.8/vendor/openzeppelin-solidity/v4.8.3/contracts/token/ERC20/utils/SafeERC20.sol";
+import {IERC20} from
+    "@chainlink/contracts-ccip/src/v0.8/vendor/openzeppelin-solidity/v4.8.3/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from
+    "@chainlink/contracts-ccip/src/v0.8/vendor/openzeppelin-solidity/v4.8.3/contracts/token/ERC20/utils/SafeERC20.sol";
 import {Helper} from "script/Helper.sol";
+import {console} from "forge-std/console.sol";
 
 /**
  * THIS IS AN EXAMPLE CONTRACT THAT USES HARDCODED VALUES FOR CLARITY.
@@ -25,14 +28,21 @@ contract TokenTransferor is OwnerIsCreator, Helper {
     error DestinationChainNotAllowlisted(uint64 destinationChainSelector); // Used when the destination chain has not been allowlisted by the contract owner.
     error InvalidReceiverAddress(); // Used when the receiver address is 0.
     // Event emitted when the tokens are transferred to an account on another chain.
-    event TokensTransferred(
-        bytes32 indexed messageId, // The unique ID of the message.
-        uint64 indexed destinationChainSelector, // The chain selector of the destination chain.
-        address receiver, // The address of the receiver on the destination chain.
-        address token, // The token address that was transferred.
-        uint256 tokenAmount, // The token amount that was transferred.
-        address feeToken, // the token address used to pay CCIP fees.
-        uint256 fees // The fees paid for sending the message.
+
+    // The chain selector of the destination chain.
+    // The address of the receiver on the destination chain.
+    // The token address that was transferred.
+    // The token amount that was transferred.
+    // the token address used to pay CCIP fees.
+    // The fees paid for sending the message.
+    event TokensTransferred( // The unique ID of the message.
+        bytes32 indexed messageId,
+        uint64 indexed destinationChainSelector,
+        address receiver,
+        address token,
+        uint256 tokenAmount,
+        address feeToken,
+        uint256 fees
     );
 
     // Mapping to keep track of allowlisted destination chains.
@@ -53,8 +63,9 @@ contract TokenTransferor is OwnerIsCreator, Helper {
     /// @dev Modifier that checks if the chain with the given destinationChainSelector is allowlisted.
     /// @param _destinationChainSelector The selector of the destination chain.
     modifier onlyAllowlistedChain(uint64 _destinationChainSelector) {
-        if (!allowlistedChains[_destinationChainSelector])
+        if (!allowlistedChains[_destinationChainSelector]) {
             revert DestinationChainNotAllowlisted(_destinationChainSelector);
+        }
         _;
     }
 
@@ -69,10 +80,7 @@ contract TokenTransferor is OwnerIsCreator, Helper {
     /// @notice This function can only be called by the owner.
     /// @param _destinationChainSelector The selector of the destination chain to be updated.
     /// @param allowed The allowlist status to be set for the destination chain.
-    function allowlistDestinationChain(
-        uint64 _destinationChainSelector,
-        bool allowed
-    ) external onlyOwner {
+    function allowlistDestinationChain(uint64 _destinationChainSelector, bool allowed) external onlyOwner {
         allowlistedChains[_destinationChainSelector] = allowed;
     }
 
@@ -86,12 +94,7 @@ contract TokenTransferor is OwnerIsCreator, Helper {
     /// @param _token token address.
     /// @param _amount token amount.
     /// @return messageId The ID of the message that was sent.
-    function transferTokensPayLINK(
-        uint64 _destinationChainSelector,
-        address _receiver,
-        address _token,
-        uint256 _amount
-    )
+    function transferTokensPayLINK(uint64 _destinationChainSelector, address _receiver, address _token, uint256 _amount)
         external
         onlyOwner
         onlyAllowlistedChain(_destinationChainSelector)
@@ -100,21 +103,15 @@ contract TokenTransferor is OwnerIsCreator, Helper {
     {
         // Create an EVM2AnyMessage struct in memory with necessary information for sending a cross-chain message
         //  address(linkToken) means fees are paid in LINK
-        Client.EVM2AnyMessage memory evm2AnyMessage = _buildCCIPMessage(
-            _receiver,
-            _token,
-            _amount,
-            address(s_linkToken)
-        );
+        Client.EVM2AnyMessage memory evm2AnyMessage =
+            _buildCCIPMessage(_receiver, _token, _amount, address(s_linkToken));
 
         // Get the fee required to send the message
-        uint256 fees = s_router.getFee(
-            _destinationChainSelector,
-            evm2AnyMessage
-        );
+        uint256 fees = s_router.getFee(_destinationChainSelector, evm2AnyMessage);
 
-        if (fees > s_linkToken.balanceOf(address(this)))
+        if (fees > s_linkToken.balanceOf(address(this))) {
             revert NotEnoughBalance(s_linkToken.balanceOf(address(this)), fees);
+        }
 
         // approve the Router to transfer LINK tokens on contract's behalf. It will spend the fees in LINK
         s_linkToken.approve(address(s_router), fees);
@@ -123,20 +120,11 @@ contract TokenTransferor is OwnerIsCreator, Helper {
         IERC20(_token).approve(address(s_router), _amount);
 
         // Send the message through the router and store the returned message ID
-        messageId = s_router.ccipSend(
-            _destinationChainSelector,
-            evm2AnyMessage
-        );
+        messageId = s_router.ccipSend(_destinationChainSelector, evm2AnyMessage);
 
         // Emit an event with message details
         emit TokensTransferred(
-            messageId,
-            _destinationChainSelector,
-            _receiver,
-            _token,
-            _amount,
-            address(s_linkToken),
-            fees
+            messageId, _destinationChainSelector, _receiver, _token, _amount, address(s_linkToken), fees
         );
 
         // Return the message ID
@@ -165,43 +153,26 @@ contract TokenTransferor is OwnerIsCreator, Helper {
         validateReceiver(_receiver)
         returns (bytes32 messageId)
     {
+        console.log("here");
         // Create an EVM2AnyMessage struct in memory with necessary information for sending a cross-chain message
         // address(0) means fees are paid in native gas
-        Client.EVM2AnyMessage memory evm2AnyMessage = _buildCCIPMessage(
-            _receiver,
-            _token,
-            _amount,
-            address(0)
-        );
+        Client.EVM2AnyMessage memory evm2AnyMessage = _buildCCIPMessage(_receiver, _token, _amount, address(0));
 
         // Get the fee required to send the message
-        uint256 fees = s_router.getFee(
-            _destinationChainSelector,
-            evm2AnyMessage
-        );
+        uint256 fees = s_router.getFee(_destinationChainSelector, evm2AnyMessage);
 
-        if (fees > address(this).balance)
+        if (fees > address(this).balance) {
             revert NotEnoughBalance(address(this).balance, fees);
+        }
 
         // approve the Router to spend tokens on contract's behalf. It will spend the amount of the given token
         IERC20(_token).approve(address(s_router), _amount);
 
         // Send the message through the router and store the returned message ID
-        messageId = s_router.ccipSend{value: fees}(
-            _destinationChainSelector,
-            evm2AnyMessage
-        );
+        messageId = s_router.ccipSend{value: fees}(_destinationChainSelector, evm2AnyMessage);
 
         // Emit an event with message details
-        emit TokensTransferred(
-            messageId,
-            _destinationChainSelector,
-            _receiver,
-            _token,
-            _amount,
-            address(0),
-            fees
-        );
+        emit TokensTransferred(messageId, _destinationChainSelector, _receiver, _token, _amount, address(0), fees);
 
         // Return the message ID
         return messageId;
@@ -214,33 +185,27 @@ contract TokenTransferor is OwnerIsCreator, Helper {
     /// @param _amount The amount of the token to be transferred.
     /// @param _feeTokenAddress The address of the token used for fees. Set address(0) for native gas.
     /// @return Client.EVM2AnyMessage Returns an EVM2AnyMessage struct which contains information for sending a CCIP message.
-    function _buildCCIPMessage(
-        address _receiver,
-        address _token,
-        uint256 _amount,
-        address _feeTokenAddress
-    ) private pure returns (Client.EVM2AnyMessage memory) {
+    function _buildCCIPMessage(address _receiver, address _token, uint256 _amount, address _feeTokenAddress)
+        private
+        pure
+        returns (Client.EVM2AnyMessage memory)
+    {
         // Set the token amounts
-        Client.EVMTokenAmount[]
-            memory tokenAmounts = new Client.EVMTokenAmount[](1);
-        tokenAmounts[0] = Client.EVMTokenAmount({
-            token: _token,
-            amount: _amount
-        });
+        Client.EVMTokenAmount[] memory tokenAmounts = new Client.EVMTokenAmount[](1);
+        tokenAmounts[0] = Client.EVMTokenAmount({token: _token, amount: _amount});
 
         // Create an EVM2AnyMessage struct in memory with necessary information for sending a cross-chain message
-        return
-            Client.EVM2AnyMessage({
-                receiver: abi.encode(_receiver), // ABI-encoded receiver address
-                data: "", // No data
-                tokenAmounts: tokenAmounts, // The amount and type of token being transferred
-                extraArgs: Client._argsToBytes(
-                    // Additional arguments, setting gas limit to 0 as we are not sending any data
-                    Client.EVMExtraArgsV1({gasLimit: 0})
-                ),
-                // Set the feeToken to a feeTokenAddress, indicating specific asset will be used for fees
-                feeToken: _feeTokenAddress
-            });
+        return Client.EVM2AnyMessage({
+            receiver: abi.encode(_receiver), // ABI-encoded receiver address
+            data: "", // No data
+            tokenAmounts: tokenAmounts, // The amount and type of token being transferred
+            extraArgs: Client._argsToBytes(
+                // Additional arguments, setting gas limit to 0 as we are not sending any data
+                Client.EVMExtraArgsV1({gasLimit: 0})
+            ),
+            // Set the feeToken to a feeTokenAddress, indicating specific asset will be used for fees
+            feeToken: _feeTokenAddress
+        });
     }
 
     /// @notice Fallback function to allow the contract to receive Ether.
@@ -260,7 +225,7 @@ contract TokenTransferor is OwnerIsCreator, Helper {
         if (amount == 0) revert NothingToWithdraw();
 
         // Attempt to send the funds, capturing the success status and discarding any return data
-        (bool sent, ) = _beneficiary.call{value: amount}("");
+        (bool sent,) = _beneficiary.call{value: amount}("");
 
         // Revert if the send failed, with information about the attempted transfer
         if (!sent) revert FailedToWithdrawEth(msg.sender, _beneficiary, amount);
@@ -270,10 +235,7 @@ contract TokenTransferor is OwnerIsCreator, Helper {
     /// @dev This function reverts with a 'NothingToWithdraw' error if there are no tokens to withdraw.
     /// @param _beneficiary The address to which the tokens will be sent.
     /// @param _token The contract address of the ERC20 token to be withdrawn.
-    function withdrawToken(
-        address _beneficiary,
-        address _token
-    ) public onlyOwner {
+    function withdrawToken(address _beneficiary, address _token) public onlyOwner {
         // Retrieve the balance of this contract
         uint256 amount = IERC20(_token).balanceOf(address(this));
 


### PR DESCRIPTION
Initialized `supportedNetworksMapping` in the constructor of the **`Helper`** contract and funded the **`TokenTransferor`** contract with **LINK** and **CCIP-BnM** tokens in the `test_tranferTokensFromEoaToEoaPayFeesInLink` test.

### script/Helper.sol

Added these lines in the `constructor`:

```js
supportedNetworksMapping["Ethereum Sepolia"] = SupportedNetworks.ETHEREUM_SEPOLIA;
supportedNetworksMapping["Avalanche Fuji"] = SupportedNetworks.AVALANCHE_FUJI;
supportedNetworksMapping["Arbitrum Sepolia"] = SupportedNetworks.ARBITRUM_SEPOLIA;
supportedNetworksMapping["Polygon Amoy"] = SupportedNetworks.POLYGON_AMOY;
supportedNetworksMapping["BNB Chain Testnet"] = SupportedNetworks.BNB_CHAIN_TESTNET;
supportedNetworksMapping["Optimism Sepolia"] = SupportedNetworks.OPTIMISM_SEPOLIA;
supportedNetworksMapping["Base Sepolia"] = SupportedNetworks.BASE_SEPOLIA;
supportedNetworksMapping["Wemix Testnet"] = SupportedNetworks.WEMIX_TESTNET;
supportedNetworksMapping["Kroma Sepolia"] = SupportedNetworks.KROMA_SEPOLIA;
supportedNetworksMapping["Gnosis Chiado"] = SupportedNetworks.GNOSIS_CHIADO;
supportedNetworksMapping["Celo Alfajores"] = SupportedNetworks.CELO_ALFAJORES;
```

### test/TokenTransferor.t.sol

Added this import:

```js
import {IERC20} from
    "@chainlink/contracts-ccip/src/v0.8/vendor/openzeppelin-solidity/v4.8.3/contracts/token/ERC20/IERC20.sol";
```

Added these lines in the `test_tranferTokensFromEoaToEoaPayFeesInLink` test before calling the `transferTokensPayLINK()` function:

```js
LinkTokenInterface(linkToken).transfer(address(tokenTransferror), 1 ether);
IERC20(tokenToSend).transfer(address(tokenTransferror), amount);
```

